### PR TITLE
Added connection options to DSN string

### DIFF
--- a/src/LMongo/Connection.php
+++ b/src/LMongo/Connection.php
@@ -109,7 +109,7 @@ class Connection {
 
 			if ($config['options'])
 			{
-				$options = [];
+				$options = array();
 				foreach ($config['options'] as $k => $v)
 				{
 					$options[] = "{$k}={$v}";

--- a/src/LMongo/Connection.php
+++ b/src/LMongo/Connection.php
@@ -99,6 +99,28 @@ class Connection {
 
 		$dsn.= "/{$database}";
 
+		$config['options'] = array_filter($config['options']);
+
+		if (isset($config['options']))
+		{
+			//	Filtering out only NULLs & false values since 0 is a valid value sometimes.
+			//	See http://docs.mongodb.org/manual/reference/connection-string/#connection-string-options
+			$config['options'] = array_filter($config['options'], function($v){
+				return $v !== NULL && $v !== false;
+			});
+
+			if ($config['options'])
+			{
+				$options = [];
+				foreach ($config['options'] as $k => $v)
+				{
+					$options[] = "{$k}={$v}";
+				}
+				$options = implode('&', $options);
+				$dsn.= "?" . $options;
+			}
+		}
+
 		return $dsn;
 	}
 

--- a/src/LMongo/Connection.php
+++ b/src/LMongo/Connection.php
@@ -99,8 +99,6 @@ class Connection {
 
 		$dsn.= "/{$database}";
 
-		$config['options'] = array_filter($config['options']);
-
 		if (isset($config['options']))
 		{
 			//	Filtering out only NULLs & false values since 0 is a valid value sometimes.

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -22,6 +22,8 @@ return array(
             'host'     => '127.0.0.1',
             'port'     => 27017,
             'database' => 'laravel',
+
+            'options'  => array()
         ),
     ),
 );


### PR DESCRIPTION
Hey.

We want to employ LMongo in our development, but the lib lacks support for DSN options to control replication, timeouts, read/write preferences, etc.

So here they go.
